### PR TITLE
Update wiringPi.c

### DIFF
--- a/src/libwiringPi/wiringPi.c
+++ b/src/libwiringPi/wiringPi.c
@@ -128,7 +128,7 @@ unsigned int micros(void) {
 
 void delay(unsigned int howLongMillis) {
 
-	usleep (howLongMillis / 1000);
+	usleep (howLongMillis * 1000);
 }
 
 


### PR DESCRIPTION
usleep takes input in microseconds, so milliseconds need to be multiplied by 1000 in order for delay to be correct.